### PR TITLE
Style fix

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
@@ -73,6 +73,10 @@ introSkipper.injectCss = function () {
         }
     }
 
+    #skipIntro .paper-icon-button-light.show-focus:focus {
+        transform: scale(1.04) !important;
+    }
+    
     #skipIntro.upNextContainer {
         width: unset;
     }


### PR DESCRIPTION
Adjust the scale factor to ensure visual consistency. Currently, the default scale factor causes the 'skip intro' text to appear disproportionately larger than the surrounding box upon selection of the skip button within the TV layout. This reduces the scale factor appropriately.