### PR TITLE
Auto-Detection Configuration

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
@@ -95,7 +95,7 @@ public class Entrypoint : IServerEntryPoint
     private void OnItemAdded(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
         // Don't do anything if auto detection is disabled
-        if (Plugin.Instance!.Configuration.!AutoDetectIntros && Plugin.Instance!.Configuration.!AutoDetectCredits)
+        if (!Plugin.Instance!.Configuration.AutoDetectIntros && !Plugin.Instance!.Configuration.AutoDetectCredits)
         {
             return;
         }
@@ -122,7 +122,7 @@ public class Entrypoint : IServerEntryPoint
     private void OnItemModified(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
         // Don't do anything if auto detection is disabled
-        if (Plugin.Instance!.Configuration.!AutoDetectIntros && Plugin.Instance!.Configuration.!AutoDetectCredits)
+        if (!Plugin.Instance!.Configuration.AutoDetectIntros && !Plugin.Instance!.Configuration.AutoDetectCredits)
         {
             return;
         }
@@ -149,7 +149,7 @@ public class Entrypoint : IServerEntryPoint
     private void OnLibraryRefresh(object? sender, TaskCompletionEventArgs eventArgs)
     {
         // Don't do anything if auto detection is disabled
-        if (Plugin.Instance!.Configuration.!AutoDetectIntros && Plugin.Instance!.Configuration.!AutoDetectCredits)
+        if (!Plugin.Instance!.Configuration.AutoDetectIntros && !Plugin.Instance!.Configuration.AutoDetectCredits)
         {
             return;
         }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
@@ -62,12 +62,9 @@ public class Entrypoint : IServerEntryPoint
     /// <returns>Task.</returns>
     public Task RunAsync()
     {
-        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
-        {
-            _libraryManager.ItemAdded += OnItemAdded;
-            _libraryManager.ItemUpdated += OnItemModified;
-            _taskManager.TaskCompleted += OnLibraryRefresh;
-        }
+        _libraryManager.ItemAdded += OnItemAdded;
+        _libraryManager.ItemUpdated += OnItemModified;
+        _taskManager.TaskCompleted += OnLibraryRefresh;
 
         FFmpegWrapper.Logger = _logger;
 
@@ -97,6 +94,12 @@ public class Entrypoint : IServerEntryPoint
     /// <param name="itemChangeEventArgs">The <see cref="ItemChangeEventArgs"/>.</param>
     private void OnItemAdded(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
+        // Don't do anything if auto detection is disabled
+        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
+        {
+            return;
+        }
+        
         // Don't do anything if it's not a supported media type
         if (itemChangeEventArgs.Item is not Episode)
         {
@@ -118,6 +121,12 @@ public class Entrypoint : IServerEntryPoint
     /// <param name="itemChangeEventArgs">The <see cref="ItemChangeEventArgs"/>.</param>
     private void OnItemModified(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
+        // Don't do anything if auto detection is disabled
+        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
+        {
+            return;
+        }
+        
         // Don't do anything if it's not a supported media type
         if (itemChangeEventArgs.Item is not Episode)
         {
@@ -139,6 +148,12 @@ public class Entrypoint : IServerEntryPoint
     /// <param name="eventArgs">The <see cref="TaskCompletionEventArgs"/>.</param>
     private void OnLibraryRefresh(object? sender, TaskCompletionEventArgs eventArgs)
     {
+        // Don't do anything if auto detection is disabled
+        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
+        {
+            return;
+        }
+        
         var result = eventArgs.Result;
 
         if (result.Key != "RefreshLibrary")

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
@@ -99,7 +99,7 @@ public class Entrypoint : IServerEntryPoint
         {
             return;
         }
-        
+
         // Don't do anything if it's not a supported media type
         if (itemChangeEventArgs.Item is not Episode)
         {
@@ -126,7 +126,7 @@ public class Entrypoint : IServerEntryPoint
         {
             return;
         }
-        
+
         // Don't do anything if it's not a supported media type
         if (itemChangeEventArgs.Item is not Episode)
         {
@@ -153,7 +153,7 @@ public class Entrypoint : IServerEntryPoint
         {
             return;
         }
-        
+
         var result = eventArgs.Result;
 
         if (result.Key != "RefreshLibrary")

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
@@ -95,7 +95,7 @@ public class Entrypoint : IServerEntryPoint
     private void OnItemAdded(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
         // Don't do anything if auto detection is disabled
-        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
+        if (Plugin.Instance!.Configuration.!AutoDetectIntros && Plugin.Instance!.Configuration.!AutoDetectCredits)
         {
             return;
         }
@@ -122,7 +122,7 @@ public class Entrypoint : IServerEntryPoint
     private void OnItemModified(object? sender, ItemChangeEventArgs itemChangeEventArgs)
     {
         // Don't do anything if auto detection is disabled
-        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
+        if (Plugin.Instance!.Configuration.!AutoDetectIntros && Plugin.Instance!.Configuration.!AutoDetectCredits)
         {
             return;
         }
@@ -149,7 +149,7 @@ public class Entrypoint : IServerEntryPoint
     private void OnLibraryRefresh(object? sender, TaskCompletionEventArgs eventArgs)
     {
         // Don't do anything if auto detection is disabled
-        if (Plugin.Instance!.Configuration.AutoDetectIntros || Plugin.Instance!.Configuration.AutoDetectCredits)
+        if (Plugin.Instance!.Configuration.!AutoDetectIntros && Plugin.Instance!.Configuration.!AutoDetectCredits)
         {
             return;
         }


### PR DESCRIPTION
Previously, changes to AutoDetectIntros and AutoDetectCredits required a restart. This allows to adapt configuration changes without restarting.