### PR TITLE
Make Entrypoint run at start

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
@@ -84,6 +84,13 @@ public class Entrypoint : IHostedService, IDisposable
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        _libraryManager.ItemAdded -= OnItemAdded;
+        _libraryManager.ItemUpdated -= OnItemModified;
+        _taskManager.TaskCompleted -= OnLibraryRefresh;
+
+        // Stop the timer
+        _queueTimer.Change(Timeout.Infinite, 0);
+
         return Task.CompletedTask;
     }
 
@@ -283,10 +290,6 @@ public class Entrypoint : IHostedService, IDisposable
     {
         if (!dispose)
         {
-            _libraryManager.ItemAdded -= OnItemAdded;
-            _libraryManager.ItemUpdated -= OnItemModified;
-            _taskManager.TaskCompleted -= OnLibraryRefresh;
-
             _queueTimer.Dispose();
 
             return;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/PluginServiceRegistrator.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/PluginServiceRegistrator.cs
@@ -13,6 +13,7 @@ namespace ConfusedPolarBear.Plugin.IntroSkipper
         public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
             serviceCollection.AddHostedService<AutoSkip>();
+            serviceCollection.AddHostedService<Entrypoint>();
         }
     }
 }


### PR DESCRIPTION
Fixes              

>  I'm noticing an issue with the Entrypoint on version 10.9. In 10.8, the log entry 'ConfusedPolarBear.Plugin.IntroSkipper.Entrypoint: Running startup enqueue' appears on start, but it's missing in 10.9. Is Entrypoint not working?