### PR TITLE
Refactor BaseItemAnalyzerTask and add Edl support for credits

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -193,7 +193,7 @@
                                     </option>
 
                                     <option value="Intro">
-                                        Intro (show a skip button, *experimental*)
+                                        Intro/Credit (show a skip button, *experimental*)
                                     </option>
 
                                     <option value="Mute">

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -223,7 +223,7 @@
 
                                 <div class="fieldDescription">
                                     If checked, the plugin will <strong>overwrite all EDL files</strong> associated with
-                                    your episodes with the currently discovered introduction timestamps and EDL action.
+                                    your episodes with the currently discovered introduction/credit timestamps and EDL action.
                                 </div>
                             </div>
                         </details>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Data/EdlAction.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Data/EdlAction.cs
@@ -34,4 +34,9 @@ public enum EdlAction
     /// Show a skip button.
     /// </summary>
     Intro,
+
+    /// <summary>
+    /// Show a skip button.
+    /// </summary>
+    Credit,
 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Entrypoint.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -250,45 +252,33 @@ public class Entrypoint : IHostedService, IDisposable
             var progress = new Progress<double>();
             var cancellationToken = _cancellationTokenSource.Token;
 
+            var modes = new List<AnalysisMode>();
+            var tasklogger = _loggerFactory.CreateLogger("DefaultLogger");
+
             if (Plugin.Instance!.Configuration.AutoDetectIntros && Plugin.Instance!.Configuration.AutoDetectCredits)
             {
-                // This is where we can optimize a single scan
-                var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-                    AnalysisMode.Introduction,
-                    _loggerFactory.CreateLogger<DetectIntrosCreditsTask>(),
-                    _loggerFactory,
-                    _libraryManager);
-
-                baseIntroAnalyzer.AnalyzeItems(progress, cancellationToken);
-
-                var baseCreditAnalyzer = new BaseItemAnalyzerTask(
-                    AnalysisMode.Credits,
-                    _loggerFactory.CreateLogger<DetectIntrosCreditsTask>(),
-                    _loggerFactory,
-                    _libraryManager);
-
-                baseCreditAnalyzer.AnalyzeItems(progress, cancellationToken);
+                modes.Add(AnalysisMode.Introduction);
+                modes.Add(AnalysisMode.Credits);
+                tasklogger = _loggerFactory.CreateLogger<DetectIntrosCreditsTask>();
             }
             else if (Plugin.Instance!.Configuration.AutoDetectIntros)
             {
-                var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-                    AnalysisMode.Introduction,
-                    _loggerFactory.CreateLogger<DetectIntrosTask>(),
-                    _loggerFactory,
-                    _libraryManager);
-
-                baseIntroAnalyzer.AnalyzeItems(progress, cancellationToken);
+                modes.Add(AnalysisMode.Introduction);
+                tasklogger = _loggerFactory.CreateLogger<DetectIntrosTask>();
             }
             else if (Plugin.Instance!.Configuration.AutoDetectCredits)
             {
-                var baseCreditAnalyzer = new BaseItemAnalyzerTask(
-                    AnalysisMode.Credits,
-                    _loggerFactory.CreateLogger<DetectCreditsTask>(),
+                modes.Add(AnalysisMode.Credits);
+                tasklogger = _loggerFactory.CreateLogger<DetectCreditsTask>();
+            }
+
+            var baseCreditAnalyzer = new BaseItemAnalyzerTask(
+                    modes.AsReadOnly(),
+                    tasklogger,
                     _loggerFactory,
                     _libraryManager);
 
-                baseCreditAnalyzer.AnalyzeItems(progress, cancellationToken);
-            }
+            baseCreditAnalyzer.AnalyzeItems(progress, cancellationToken);
         }
 
         _autoTaskCompletEvent.Set();

--- a/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
@@ -237,7 +237,7 @@ public class QueueManager
         {
             try
             {
-                var path = Plugin.Instance.GetItemPath(candidate.EpisodeId);
+                var path = Plugin.Instance!.GetItemPath(candidate.EpisodeId);
 
                 if (File.Exists(path))
                 {

--- a/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/QueueManager.cs
@@ -219,17 +219,16 @@ public class QueueManager
     /// This is done to ensure that we don't analyze items that were deleted between the call to GetMediaItems() and popping them from the queue.
     /// </summary>
     /// <param name="candidates">Queued media items.</param>
-    /// <param name="mode">Analysis mode.</param>
+    /// <param name="modes">Analysis mode.</param>
     /// <returns>Media items that have been verified to exist in Jellyfin and in storage.</returns>
-    public (ReadOnlyCollection<QueuedEpisode> VerifiedItems, bool AnyUnanalyzed)
-        VerifyQueue(ReadOnlyCollection<QueuedEpisode> candidates, AnalysisMode mode)
+    public (ReadOnlyCollection<QueuedEpisode> VerifiedItems, ReadOnlyCollection<AnalysisMode> RequiredModes)
+        VerifyQueue(ReadOnlyCollection<QueuedEpisode> candidates, ReadOnlyCollection<AnalysisMode> modes)
     {
-        var unanalyzed = false;
         var verified = new List<QueuedEpisode>();
+        var reqModes = new List<AnalysisMode>();
 
-        var timestamps = mode == AnalysisMode.Introduction ?
-                Plugin.Instance!.Intros :
-                Plugin.Instance!.Credits;
+        var requiresIntroAnalysis = modes.Contains(AnalysisMode.Introduction);
+        var requiresCreditsAnalysis = modes.Contains(AnalysisMode.Credits);
 
         foreach (var candidate in candidates)
         {
@@ -240,24 +239,31 @@ public class QueueManager
                 if (File.Exists(path))
                 {
                     verified.Add(candidate);
-                }
 
-                if (!timestamps.ContainsKey(candidate.EpisodeId))
-                {
-                    unanalyzed = true;
+                    if (requiresIntroAnalysis && !Plugin.Instance!.Intros.ContainsKey(candidate.EpisodeId))
+                    {
+                        reqModes.Add(AnalysisMode.Introduction);
+                        requiresIntroAnalysis = false;  // No need to check again
+                    }
+
+                    if (requiresCreditsAnalysis && !Plugin.Instance!.Credits.ContainsKey(candidate.EpisodeId))
+                    {
+                        reqModes.Add(AnalysisMode.Credits);
+                        requiresCreditsAnalysis = false; // No need to check again
+                    }
                 }
             }
             catch (Exception ex)
             {
                 _logger.LogDebug(
                     "Skipping {Mode} analysis of {Name} ({Id}): {Exception}",
-                    mode,
+                    modes,
                     candidate.Name,
                     candidate.EpisodeId,
                     ex);
             }
         }
 
-        return (verified.AsReadOnly(), unanalyzed);
+        return (verified.AsReadOnly(), reqModes.AsReadOnly());
     }
 }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -182,7 +182,8 @@ public class BaseItemAnalyzerTask
         }
 
         _logger.LogInformation(
-            "Analyzing {Count} files from {Name} season {Season}",
+            "[Mode: {Mode}] Analyzing {Count} files from {Name} season {Season}",
+            mode,
             items.Count,
             first.SeriesName,
             first.SeasonNumber);

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -74,6 +74,8 @@ public class BaseItemAnalyzerTask
             totalQueued += kvp.Value.Count;
         }
 
+        totalQueued *= _analysisModes.Count;
+
         if (totalQueued == 0)
         {
             throw new FingerprintException(
@@ -131,6 +133,8 @@ public class BaseItemAnalyzerTask
                     Interlocked.Add(ref totalProcessed, analyzed);
 
                     writeEdl = analyzed > 0 || Plugin.Instance!.Configuration.RegenerateEdlFiles;
+
+                    progress.Report((totalProcessed * 100) / totalQueued);
                 }
             }
             catch (FingerprintException ex)
@@ -146,8 +150,6 @@ public class BaseItemAnalyzerTask
             {
                 EdlManager.UpdateEDLFiles(episodes);
             }
-
-            progress.Report((totalProcessed * 100) / totalQueued);
         });
 
         if (Plugin.Instance!.Configuration.RegenerateEdlFiles)

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -114,13 +114,13 @@ public class BaseItemAnalyzerTask
             var first = episodes[0];
             var requiredModeCount = requiredModes.Count;
 
-            if (requiredModeCount == 0) 
+            if (requiredModeCount == 0)
             {
                 _logger.LogDebug(
                     "All episodes in {Name} season {Season} have already been analyzed",
                     first.SeriesName,
                     first.SeasonNumber);
-                    
+
                 Interlocked.Add(ref totalProcessed, (episodeCount * modeCount)); // Update totalProcessed directly
                 progress.Report((totalProcessed * 100) / totalQueued);
 

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -121,7 +121,7 @@ public class BaseItemAnalyzerTask
                     first.SeriesName,
                     first.SeasonNumber);
 
-                Interlocked.Add(ref totalProcessed, (episodeCount * modeCount)); // Update totalProcessed directly
+                Interlocked.Add(ref totalProcessed, episodeCount * modeCount); // Update total Processed directly
                 progress.Report((totalProcessed * 100) / totalQueued);
 
                 return;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectCreditsTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectCreditsTask.cs
@@ -87,6 +87,7 @@ public class DetectCreditsTask : IScheduledTask
 
         _logger.LogInformation("Scheduled Task is starting");
 
+        Plugin.Instance!.Configuration.PathRestrictions.Clear();
         var modes = new List<AnalysisMode> { AnalysisMode.Credits };
 
         var baseCreditAnalyzer = new BaseItemAnalyzerTask(

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectCreditsTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectCreditsTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Library;
@@ -86,8 +87,10 @@ public class DetectCreditsTask : IScheduledTask
 
         _logger.LogInformation("Scheduled Task is starting");
 
+        var modes = new List<AnalysisMode> { AnalysisMode.Credits };
+
         var baseCreditAnalyzer = new BaseItemAnalyzerTask(
-            AnalysisMode.Credits,
+            modes.AsReadOnly(),
             _loggerFactory.CreateLogger<DetectCreditsTask>(),
             _loggerFactory,
             _libraryManager);

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosCreditsTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosCreditsTask.cs
@@ -86,6 +86,7 @@ public class DetectIntrosCreditsTask : IScheduledTask
 
         _logger.LogInformation("Scheduled Task is starting");
 
+        Plugin.Instance!.Configuration.PathRestrictions.Clear();
         var modes = new List<AnalysisMode> { AnalysisMode.Introduction, AnalysisMode.Credits };
 
         var baseIntroAnalyzer = new BaseItemAnalyzerTask(

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosCreditsTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosCreditsTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Library;
@@ -85,21 +86,15 @@ public class DetectIntrosCreditsTask : IScheduledTask
 
         _logger.LogInformation("Scheduled Task is starting");
 
+        var modes = new List<AnalysisMode> { AnalysisMode.Introduction, AnalysisMode.Credits };
+
         var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-            AnalysisMode.Introduction,
+            modes.AsReadOnly(),
             _loggerFactory.CreateLogger<DetectIntrosCreditsTask>(),
             _loggerFactory,
             _libraryManager);
 
         baseIntroAnalyzer.AnalyzeItems(progress, cancellationToken);
-
-        var baseCreditAnalyzer = new BaseItemAnalyzerTask(
-            AnalysisMode.Credits,
-            _loggerFactory.CreateLogger<DetectIntrosCreditsTask>(),
-            _loggerFactory,
-            _libraryManager);
-
-        baseCreditAnalyzer.AnalyzeItems(progress, cancellationToken);
 
         ScheduledTaskSemaphore.Release();
         return Task.CompletedTask;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.Library;
@@ -85,8 +86,10 @@ public class DetectIntrosTask : IScheduledTask
 
         _logger.LogInformation("Scheduled Task is starting");
 
+        var modes = new List<AnalysisMode> { AnalysisMode.Introduction };
+
         var baseIntroAnalyzer = new BaseItemAnalyzerTask(
-            AnalysisMode.Introduction,
+            modes.AsReadOnly(),
             _loggerFactory.CreateLogger<DetectIntrosTask>(),
             _loggerFactory,
             _libraryManager);

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/DetectIntrosTask.cs
@@ -86,6 +86,7 @@ public class DetectIntrosTask : IScheduledTask
 
         _logger.LogInformation("Scheduled Task is starting");
 
+        Plugin.Instance!.Configuration.PathRestrictions.Clear();
         var modes = new List<AnalysisMode> { AnalysisMode.Introduction };
 
         var baseIntroAnalyzer = new BaseItemAnalyzerTask(


### PR DESCRIPTION
- Refactored BaseItemAnalyzerTask to use `ReadOnlyCollection<AnalysisMode>` for input.
- Added support for credits in Edl files.
- Review for the BaseItemAnalyzerTask refactor would be appreciated.

