### PR TITLE
change chromaprint offset, reorder analyzers, improve prompt timing

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Analyzers/BlackFrameAnalyzer.cs
@@ -168,7 +168,7 @@ public class BlackFrameAnalyzer : IMediaFileAnalyzer
             if (frames.Length == 0)
             {
                 // Since no black frames were found, slide the range closer to the end
-                start = midpoint;
+                start = midpoint - TimeSpan.FromSeconds(2);
 
                 if (midpoint - TimeSpan.FromSeconds(lowerLimit) < _maximumError)
                 {

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Analyzers/ChromaprintAnalyzer.cs
@@ -17,7 +17,7 @@ public class ChromaprintAnalyzer : IMediaFileAnalyzer
     /// Seconds of audio in one fingerprint point.
     /// This value is defined by the Chromaprint library and should not be changed.
     /// </summary>
-    private const double SamplesToSeconds = 0.128;
+    private const double SamplesToSeconds = 0.1238;
 
     private int minimumIntroDuration;
 

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -531,14 +531,14 @@
                                 <tr>
                                     <td>Up arrow</td>
                                     <td>
-                                        Shift the left episode up by 0.128 seconds.
+                                        Shift the left episode up by 0.1238 seconds.
                                         Holding control will shift the episode by 10 seconds.
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>Down arrow</td>
                                     <td>
-                                        Shift the left episode down by 0.128 seconds.
+                                        Shift the left episode down by 0.1238 seconds.
                                         Holding control will shift the episode by 10 seconds.
                                     </td>
                                 </tr>
@@ -919,13 +919,13 @@
                     case "ArrowDown":
                         if (timestampError.value != "") {
                             // if the control key is pressed, shift LHS by 10s. Otherwise, shift by 1.
-                            offsetDelta = e.ctrlKey ? 10 / 0.128 : 1;
+                            offsetDelta = e.ctrlKey ? 10 / 0.1238 : 1;
                         }
                         break;
 
                     case "ArrowUp":
                         if (timestampError.value != "") {
-                            offsetDelta = e.ctrlKey ? -10 / 0.128 : -1;
+                            offsetDelta = e.ctrlKey ? -10 / 0.1238 : -1;
                         }
                         break;
 
@@ -1108,12 +1108,12 @@
 
                 let lTime, rTime, diffPos;
                 if (shift < 0) {
-                    lTime = y * 0.128;
-                    rTime = (y + shift) * 0.128;
+                    lTime = y * 0.1238;
+                    rTime = (y + shift) * 0.1238;
                     diffPos = y + shift;
                 } else {
-                    lTime = (y - shift) * 0.128;
-                    rTime = y * 0.128;
+                    lTime = (y - shift) * 0.1238;
+                    rTime = y * 0.1238;
                     diffPos = y - shift;
                 }
 

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
@@ -91,14 +91,14 @@ public class SkipIntroController : ControllerBase
             if (config.PersistSkipButton)
             {
                 segment.ShowSkipPromptAt = segment.IntroStart;
-                segment.HideSkipPromptAt = segment.IntroEnd;
+                segment.HideSkipPromptAt = segment.IntroEnd - 1;
             }
             else
             {
                 segment.ShowSkipPromptAt = Math.Max(0, segment.IntroStart - config.ShowPromptAdjustment);
                 segment.HideSkipPromptAt = Math.Min(
                     segment.IntroStart + config.HidePromptAdjustment,
-                    segment.IntroEnd);
+                    segment.IntroEnd - 1);
             }
 
             return segment;

--- a/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/ScheduledTasks/BaseItemAnalyzerTask.cs
@@ -204,14 +204,14 @@ public class BaseItemAnalyzerTask
         var analyzers = new Collection<IMediaFileAnalyzer>();
 
         analyzers.Add(new ChapterAnalyzer(_loggerFactory.CreateLogger<ChapterAnalyzer>()));
-        if (Plugin.Instance!.Configuration.UseChromaprint)
-        {
-            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
-        }
-
         if (mode == AnalysisMode.Credits)
         {
             analyzers.Add(new BlackFrameAnalyzer(_loggerFactory.CreateLogger<BlackFrameAnalyzer>()));
+        }
+
+        if (Plugin.Instance!.Configuration.UseChromaprint)
+        {
+            analyzers.Add(new ChromaprintAnalyzer(_loggerFactory.CreateLogger<ChromaprintAnalyzer>()));
         }
 
         // Use each analyzer to find skippable ranges in all media files, removing successfully


### PR DESCRIPTION
- Changed chromaprint offset to 0.1238.
- Run blackframe analyzer before chromaprints.
- Hide skip prompt earlier to prevent it from reappearing.