### PR TITLE
Fixed typo in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
                 "version": "0.2.0.6",
                 "changelog": "- See the full changelog at [GitHub](https://github.com/jumoog/intro-skipper/blob/master/CHANGELOG.md)\n",
                 "targetAbi": "10.9.0.0",
-                "sourceUrl": "https://github.com/jumoog/intro-skipper/releases/download/10.9/v0.2.0.6/intro-skipper-v0.2.0.6.zipp",
+                "sourceUrl": "https://github.com/jumoog/intro-skipper/releases/download/10.9/v0.2.0.6/intro-skipper-v0.2.0.6.zip",
                 "checksum": "819115643d6c5bb20e1abd59f886ca25",
                 "timestamp": "2024-05-18T20:45:09Z"
             },


### PR DESCRIPTION
I noted this typo is causing some error in the logs, I'm unsure if this introduces any meaningful harm.