### PR TITLE
fix: skip button icon

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
@@ -136,7 +136,7 @@ const introSkipper = {
         this.skipButton.innerHTML = `
             <button is="emby-button" type="button" class="btnSkipIntro injected">
                 <span id="btnSkipSegmentText"></span>
-                <span class="material-icons">skip_next</span>
+                <span class="material-icons skip_next"></span>
             </button>
         `;
         this.skipButton.dataset.Introduction = config.SkipButtonIntroText;


### PR DESCRIPTION
The `skip_next` icon beside the configurable text in the skip button is currently showing the class name as text, instead of rendering the icon. This problem occurred because the class name was mistakenly placed inside the element as text instead of being set correctly in the class attribute.

This PR updates the code to assign the class name to the class attribute of the span element.