### PR TITLE
AutoSkip: allow to adjust the intro/credit playback duration

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkip.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkip.cs
@@ -133,15 +133,17 @@ public class AutoSkip : IHostedService, IDisposable
             }
 
             // Seek is unreliable if called at the very start of an episode.
-            var adjustedStart = Math.Max(5, intro.IntroStart);
+            intro.IntroStart = Math.Max(5, intro.IntroStart);
+            // same logic like SkipIntroController.GetIntro()
+            intro.IntroEnd -= Plugin.Instance.Configuration.SecondsOfIntroToPlay;
 
             _logger.LogTrace(
                 "Playback position is {Position}, intro runs from {Start} to {End}",
                 position,
-                adjustedStart,
+                intro.IntroStart,
                 intro.IntroEnd);
 
-            if (position < adjustedStart || position > intro.IntroEnd)
+            if (position < intro.IntroStart || position > intro.IntroEnd)
             {
                 continue;
             }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkip.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkip.cs
@@ -134,7 +134,7 @@ public class AutoSkip : IHostedService, IDisposable
 
             // Seek is unreliable if called at the very start of an episode.
             var adjustedStart = Math.Max(5, intro.IntroStart + Plugin.Instance.Configuration.SecondsOfIntroStartToPlay);
-            var adjustedEnd = intro.IntroEnd - Plugin.Instance.Configuration.SecondsOfIntroToPlay;
+            var adjustedEnd = intro.IntroEnd - Plugin.Instance.Configuration.RemainingSecondsOfIntro;
 
             _logger.LogTrace(
                 "Playback position is {Position}, intro runs from {Start} to {End}",

--- a/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkipCredits.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkipCredits.cs
@@ -134,7 +134,7 @@ public class AutoSkipCredits : IHostedService, IDisposable
 
             // Seek is unreliable if called at the very end of an episode.
             var adjustedStart = credit.IntroStart + Plugin.Instance.Configuration.SecondsOfCreditsStartToPlay;
-            var adjustedEnd = credit.IntroEnd - Plugin.Instance.Configuration.SecondsOfIntroToPlay;
+            var adjustedEnd = credit.IntroEnd - Plugin.Instance.Configuration.RemainingSecondsOfIntro;
 
             _logger.LogTrace(
                 "Playback position is {Position}, credits run from {Start} to {End}",

--- a/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkipCredits.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkipCredits.cs
@@ -132,16 +132,17 @@ public class AutoSkipCredits : IHostedService, IDisposable
                 continue;
             }
 
-            // same logic like SkipIntroController.GetIntro()
-            credit.IntroEnd -= Plugin.Instance.Configuration.SecondsOfIntroToPlay;
+            // Seek is unreliable if called at the very end of an episode.
+            var adjustedStart = credit.IntroStart + Plugin.Instance.Configuration.SecondsOfCreditsStartToPlay;
+            var adjustedEnd = credit.IntroEnd - Plugin.Instance.Configuration.SecondsOfIntroToPlay;
 
             _logger.LogTrace(
                 "Playback position is {Position}, credits run from {Start} to {End}",
                 position,
-                credit.IntroStart,
-                credit.IntroEnd);
+                adjustedStart,
+                adjustedEnd);
 
-            if (position < credit.IntroStart || position > credit.IntroEnd)
+            if (position < adjustedStart || position > adjustedEnd)
             {
                 continue;
             }
@@ -164,8 +165,6 @@ public class AutoSkipCredits : IHostedService, IDisposable
 
             _logger.LogDebug("Sending seek command to {Session}", deviceId);
 
-            var creditEnd = (long)credit.IntroEnd;
-
             _sessionManager.SendPlaystateCommand(
                 session.Id,
                 session.Id,
@@ -173,7 +172,7 @@ public class AutoSkipCredits : IHostedService, IDisposable
                 {
                     Command = PlaystateCommand.Seek,
                     ControllingUserId = session.UserId.ToString(),
-                    SeekPositionTicks = creditEnd * TimeSpan.TicksPerSecond,
+                    SeekPositionTicks = (long)adjustedEnd * TimeSpan.TicksPerSecond,
                 },
                 CancellationToken.None);
 

--- a/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkipCredits.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/AutoSkipCredits.cs
@@ -132,16 +132,16 @@ public class AutoSkipCredits : IHostedService, IDisposable
                 continue;
             }
 
-            // Seek is unreliable if called at the very start of an episode.
-            var adjustedStart = Math.Max(5, credit.IntroStart);
+            // same logic like SkipIntroController.GetIntro()
+            credit.IntroEnd -= Plugin.Instance.Configuration.SecondsOfIntroToPlay;
 
             _logger.LogTrace(
                 "Playback position is {Position}, credits run from {Start} to {End}",
                 position,
-                adjustedStart,
+                credit.IntroStart,
                 credit.IntroEnd);
 
-            if (position < adjustedStart || position > credit.IntroEnd)
+            if (position < credit.IntroStart || position > credit.IntroEnd)
             {
                 continue;
             }

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -158,6 +158,21 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public int SecondsOfIntroToPlay { get; set; } = 2;
 
+    /// <summary>
+    /// Gets or sets the amount of intro at start to play (in seconds).
+    /// </summary>
+    public int SecondsOfIntroStartToPlay { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the amount of credit at start to play (in seconds).
+    /// </summary>
+    public int SecondsOfCreditsStartToPlay { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the amount of credits to play (in seconds).
+    /// </summary>
+    public int SecondsOfCreditsToPlay { get; set; } = 0;
+
     // ===== Internal algorithm settings =====
 
     /// <summary>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -156,7 +156,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets the amount of intro to play (in seconds).
     /// </summary>
-    public int SecondsOfIntroToPlay { get; set; } = 2;
+    public int RemainingSecondsOfIntro { get; set; } = 2;
 
     /// <summary>
     /// Gets or sets the amount of intro at start to play (in seconds).

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/PluginConfiguration.cs
@@ -168,11 +168,6 @@ public class PluginConfiguration : BasePluginConfiguration
     /// </summary>
     public int SecondsOfCreditsStartToPlay { get; set; } = 0;
 
-    /// <summary>
-    /// Gets or sets the amount of credits to play (in seconds).
-    /// </summary>
-    public int SecondsOfCreditsToPlay { get; set; } = 0;
-
     // ===== Internal algorithm settings =====
 
     /// <summary>

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -365,6 +365,17 @@
                             <br />
                         </div>
 
+                        <div id="divSecondsOfIntroStartToPlay" class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="SecondsOfIntroStartToPlay">
+                                Intro playback duration (in seconds)
+                            </label>
+                            <input id="SecondsOfIntroStartToPlay" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">
+                                Seconds of introduction start that should be played. Defaults to 2.
+                            </div>
+                            <br />
+                        </div>
+
                         <div class="checkboxContainer checkboxContainer-withDescription">
                             <label class="emby-checkbox-label">
                                 <input id="AutoSkipCredits" type="checkbox" is="emby-checkbox" />
@@ -376,6 +387,17 @@
                                 reverse proxy, it must be configured to proxy web
                                 sockets.<br />
                             </div>
+                        </div>
+
+                        <div id="divSecondsOfCreditsStartToPlay" class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="SecondsOfCreditsStartToPlay">
+                                Credit playback duration (in seconds)
+                            </label>
+                            <input id="SecondsOfCreditsStartToPlay" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">
+                                Seconds of credits start that should be played. Defaults to 2.
+                            </div>
+                            <br />
                         </div>
 
                         <div class="checkboxContainer checkboxContainer-withDescription">
@@ -433,6 +455,16 @@
                             <input id="SecondsOfIntroToPlay" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">
                                 Seconds of introduction ending that should be played. Defaults to 2.
+                            </div>
+                        </div>
+
+                         <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="SecondsOfCreditsToPlay">
+                                Credits playback duration (in seconds)
+                            </label>
+                            <input id="SecondsOfCreditsToPlay" type="number" is="emby-input" min="0" />
+                            <div class="fieldDescription">
+                                Seconds of credits that should be played. Defaults to 0.
                             </div>
                         </div>
 
@@ -682,6 +714,9 @@
                 "ShowPromptAdjustment",
                 "HidePromptAdjustment",
                 "SecondsOfIntroToPlay",
+                "SecondsOfIntroStartToPlay",
+                "SecondsOfCreditsStartToPlay",
+                "SecondsOfCreditsToPlay",
                 // internals
                 "SilenceDetectionMaximumNoise",
                 "SilenceDetectionMinimumDuration",
@@ -725,6 +760,8 @@
 
             var autoSkip = document.querySelector("input#AutoSkip");
             var skipFirstEpisode = document.querySelector("div#divSkipFirstEpisode");
+            var secondsOfIntroStartToPlay = document.querySelector("div#divSecondsOfIntroStartToPlay");
+            var secondsOfCreditsStartToPlay = document.querySelector("div#divSecondsOfCreditsStartToPlay");
             var autoSkipNotificationText = document.querySelector("div#divAutoSkipNotificationText");
             var autoSkipCredits = document.querySelector("input#AutoSkipCredits");
             var autoSkipCreditsNotificationText = document.querySelector("div#divAutoSkipCreditsNotificationText");
@@ -733,9 +770,11 @@
                 if (autoSkip.checked) {
                     skipFirstEpisode.style.display = 'unset';
                     autoSkipNotificationText.style.display = 'unset';
+                    secondsOfIntroStartToPlay.style.display = 'unset';
                 } else {
                     skipFirstEpisode.style.display = 'none';
                     autoSkipNotificationText.style.display = 'none';
+                    secondsOfIntroStartToPlay.style.display = 'none';
                 }
             }
 
@@ -744,8 +783,10 @@
             async function autoSkipCreditsChanged() {
                 if (autoSkipCredits.checked) {
                     autoSkipCreditsNotificationText.style.display = 'unset';
+                    secondsOfCreditsStartToPlay.style.display = 'unset';
                 } else {
                     autoSkipCreditsNotificationText.style.display = 'none';
+                    secondsOfCreditsStartToPlay.style.display = 'none';
                 }
             }
 

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -449,10 +449,10 @@
                         <br />
 
                         <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="SecondsOfIntroToPlay">
+                            <label class="inputLabel inputLabelUnfocused" for="RemainingSecondsOfIntro">
                                 Intro playback duration (in seconds)
                             </label>
-                            <input id="SecondsOfIntroToPlay" type="number" is="emby-input" min="0" />
+                            <input id="RemainingSecondsOfIntro" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">
                                 Seconds of introduction ending that should be played. Defaults to 2.
                             </div>
@@ -703,7 +703,7 @@
                 // playback
                 "ShowPromptAdjustment",
                 "HidePromptAdjustment",
-                "SecondsOfIntroToPlay",
+                "RemainingSecondsOfIntro",
                 "SecondsOfIntroStartToPlay",
                 "SecondsOfCreditsStartToPlay",
                 // internals

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -371,7 +371,7 @@
                             </label>
                             <input id="SecondsOfIntroStartToPlay" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">
-                                Seconds of introduction start that should be played. Defaults to 2.
+                                Seconds of introduction start that should be played. Defaults to 0.
                             </div>
                             <br />
                         </div>
@@ -395,7 +395,7 @@
                             </label>
                             <input id="SecondsOfCreditsStartToPlay" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">
-                                Seconds of credits start that should be played. Defaults to 2.
+                                Seconds of credits start that should be played. Defaults to 0.
                             </div>
                             <br />
                         </div>
@@ -455,16 +455,6 @@
                             <input id="SecondsOfIntroToPlay" type="number" is="emby-input" min="0" />
                             <div class="fieldDescription">
                                 Seconds of introduction ending that should be played. Defaults to 2.
-                            </div>
-                        </div>
-
-                         <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="SecondsOfCreditsToPlay">
-                                Credits playback duration (in seconds)
-                            </label>
-                            <input id="SecondsOfCreditsToPlay" type="number" is="emby-input" min="0" />
-                            <div class="fieldDescription">
-                                Seconds of credits that should be played. Defaults to 0.
                             </div>
                         </div>
 
@@ -716,7 +706,6 @@
                 "SecondsOfIntroToPlay",
                 "SecondsOfIntroStartToPlay",
                 "SecondsOfCreditsStartToPlay",
-                "SecondsOfCreditsToPlay",
                 // internals
                 "SilenceDetectionMaximumNoise",
                 "SilenceDetectionMinimumDuration",

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
@@ -156,7 +156,7 @@ public class SkipIntroController : ControllerBase
             var segment = new Intro(timestamp);
 
             var config = Plugin.Instance.Configuration;
-            segment.IntroEnd -= config.SecondsOfIntroToPlay;
+            segment.IntroEnd -= config.RemainingSecondsOfIntro;
             if (config.PersistSkipButton)
             {
                 segment.ShowSkipPromptAt = segment.IntroStart;


### PR DESCRIPTION
- It is not necessary to adjust the start for credits
- Change the end, not the start