### PR TITLE
fixing the description for Automatically skip intros

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -347,7 +347,7 @@
                             </label>
 
                             <div class="fieldDescription">
-                                If checked, credits will be automatically skipped for Apps without Skip Button.
+                                If checked, intros will be automatically skipped for Apps without Skip Button.
                                 If you access Jellyfin through a reverse proxy, it must be configured to proxy websockets.<br />
                             </div>
                         </div>


### PR DESCRIPTION
fixing the description for Automatically skip intros from "If checked, credits will be automatically skipped for Apps without Skip Button."
to " If checked, intros will be automatically skipped for Apps without Skip Button."