### PR TITLE
Fix inconsistency in library selection UI

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -84,7 +84,7 @@
                                 </div>
                             </div>
                             <div class="fieldDescription">
-                                Only selected libraries will be analyzed. If no libraries are selected, all TV show libraries will be analyzed.
+                                Selected libraries will be analyzed. If none are selected, all TV show and mixed libraries will be analyzed.
                             </div>
                             <label class="inputLabel" for="SelectedLibraries"></label>
                             <input id="SelectedLibraries" type="hidden" is="emby-input" />

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -80,11 +80,11 @@
                         <div class="folderAccessListContainer">
                             <div class="folderAccess">
                                 <h4 class="checkboxListLabel">Limit analysis to the following libraries</h4>
-                                <div class="fieldDescription">
-                                    Select the libraries you want to include in the analysis. If no libraries are selected, all TV show libraries will be analyzed.
-                                </div>
                                 <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryCheckboxes">
                                 </div>
+                            </div>
+                            <div class="fieldDescription">
+                                Only selected libraries will be analyzed. If no libraries are selected, all TV show libraries will be analyzed.
                             </div>
                             <label class="inputLabel" for="SelectedLibraries"></label>
                             <input id="SelectedLibraries" type="hidden" is="emby-input" />

--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/configPage.html
@@ -79,12 +79,12 @@
 
                         <div class="folderAccessListContainer">
                             <div class="folderAccess">
-                                <h3 class="checkboxListLabel">Limit analysis to the following libraries</h3>
+                                <h4 class="checkboxListLabel">Limit analysis to the following libraries</h4>
+                                <div class="fieldDescription">
+                                    Select the libraries you want to include in the analysis. If no libraries are selected, all TV show libraries will be analyzed.
+                                </div>
                                 <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryCheckboxes">
                                 </div>
-                            </div>
-                            <div class="fieldDescription">
-                                Select the libraries you want to include in the analysis. If no libraries are selected, all TV show libraries will be analyzed.
                             </div>
                             <label class="inputLabel" for="SelectedLibraries"></label>
                             <input id="SelectedLibraries" type="hidden" is="emby-input" />
@@ -1024,7 +1024,7 @@
                 // Try to get the timestamps of each intro, falling back a default value of zero if no intro was found
                 const leftEpisodeJson = await getJson("Episode/" + leftEpisode.value + "/Timestamps");
                 const rightEpisodeJson = await getJson("Episode/" + rightEpisode.value + "/Timestamps");
-                
+
                 // Update the editor for the first and second episodes
                 timestampEditor.style.display = "unset";
                 document.querySelector("#editLeftEpisodeTitle").textContent = leftEpisode.text;
@@ -1347,7 +1347,7 @@
                 let remainingSeconds = seconds % 60;
 
                 // Format as HH:MM:SS
-                let formattedTime = 
+                let formattedTime =
                     String(hours).padStart(2, '0') + ':' +
                     String(minutes).padStart(2, '0') + ':' +
                     String(remainingSeconds).padStart(2, '0');

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
     <p>
         Analyzes the audio of television episodes to detect and skip over intros.
     </p>
-    
+
 [![CodeQL](https://github.com/jumoog/intro-skipper/actions/workflows/codeql.yml/badge.svg)](https://github.com/jumoog/intro-skipper/actions/workflows/codeql.yml)
 
-
-`https://raw.githubusercontent.com/jumoog/intro-skipper/master/manifest.json`
+    https://raw.githubusercontent.com/jumoog/intro-skipper/master/manifest.json
 </div>
 
 ## Jellyfin 10.8


### PR DESCRIPTION
Makes the label more consistent with the rest and updates the description for mixed libraries

<details>
<summary>Before</summary>

![Plugins — Mozilla Firefox 9_15_2024 10_21_57 PM](https://github.com/user-attachments/assets/a5965780-059f-4866-b9da-8faa7d5552a0)
</details>

